### PR TITLE
Fix Turso benchmark setup for Drizzle migration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -394,6 +394,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Setup Turso database
+        run: pnpm --filter @workflow-worlds/workbench exec workflow-turso-setup
+        env:
+          WORKFLOW_TURSO_DATABASE_URL: "file:benchmark.db"
+
       - name: Build workbench
         run: pnpm --filter @workflow-worlds/workbench build
         env:


### PR DESCRIPTION
Since Turso was refactored to use Drizzle (d1a4360), the benchmark workflow needs to run migrations before the server starts, similar to the PostgreSQL benchmark setup step.