### PR TITLE
fix(redis): add TLS connection options support

### DIFF
--- a/.changeset/two-facts-think.md
+++ b/.changeset/two-facts-think.md
@@ -1,0 +1,5 @@
+---
+"@workflow-worlds/redis": patch
+---
+
+fix(redis): added constructor options to connect to Redis with TLS for the main and BullMQ clients

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -48,8 +48,15 @@ interface RedisWorldConfig {
   // Redis connection string
   // Default: process.env.WORKFLOW_REDIS_URI ?? 'redis://localhost:6379'
   redisUrl?: string;
+  
+  // TLS options for Redis connection
+  tls?: {
+    key?: string | Buffer<ArrayBufferLike> | (string | Buffer<ArrayBufferLike> | KeyObject)[];
+    cert?: string | Buffer<ArrayBufferLike> | (string | Buffer<ArrayBufferLike>)[];
+    ca?: string | Buffer<ArrayBufferLike> | (string | Buffer<ArrayBufferLike>)[];
+  };
 
-  // Pre-existing ioredis client (if provided, redisUrl is ignored)
+  // Pre-existing ioredis client (if provided, redisUrl and tls are ignored)
   client?: Redis;
 
   // Key prefix for all Redis keys

--- a/packages/redis/src/queue.ts
+++ b/packages/redis/src/queue.ts
@@ -10,6 +10,7 @@
  */
 
 import { Queue, Worker, Job, type ConnectionOptions, type JobsOptions } from 'bullmq';
+import type { ConnectionOptions as TlsConnectionOptions } from 'tls';
 import type {
   Queue as WorkflowQueue,
   MessageId,
@@ -30,6 +31,11 @@ export interface QueueConfig {
    * Default: http://localhost:${PORT}
    */
   baseUrl?: string;
+
+  /**
+   * TLS options for the Redis connection.
+   */
+  tls?: TlsConnectionOptions;
 
   /**
    * Maximum concurrent message processing.
@@ -88,6 +94,11 @@ export async function createQueue(options: {
   const connection: ConnectionOptions = {
     url: redisUrl,
     maxRetriesPerRequest: null,
+    tls: config.tls ? {
+      key: config.tls.key,
+      cert: config.tls.cert,
+      ca: config.tls.ca,
+    } : undefined,
   };
 
   // Create BullMQ queues for workflow and step execution


### PR DESCRIPTION
Adds TLS Redis connection parameters to the constructor. These parameters are passed both to the main Redis client and to the BullMQ Redis client.