### PR TITLE
Add CBOR queue transport helpers for Workflow SDK spec v3

### DIFF
--- a/.changeset/cbor-transport-mongodb.md
+++ b/.changeset/cbor-transport-mongodb.md
@@ -1,0 +1,5 @@
+---
+"@workflow-worlds/mongodb": patch
+---
+
+Add `CborTransport` and `DualTransport` helpers (`src/cbor-transport.ts`) and `cbor-x` dependency for use with Workflow SDK spec version 3 (CBOR queue transport). Not yet wired into the default queue — see the upstream PR description for the migration checklist.

--- a/.changeset/cbor-transport-redis.md
+++ b/.changeset/cbor-transport-redis.md
@@ -1,0 +1,5 @@
+---
+"@workflow-worlds/redis": patch
+---
+
+Add `CborTransport`/`DualTransport` and BullMQ wrapping helpers (`src/cbor-transport.ts`) and the `@vercel/queue` dependency for use with Workflow SDK spec version 3 (CBOR queue transport). Not yet wired into the default queue — see the upstream PR description for the migration checklist.

--- a/.changeset/cbor-transport-turso.md
+++ b/.changeset/cbor-transport-turso.md
@@ -1,0 +1,5 @@
+---
+"@workflow-worlds/turso": patch
+---
+
+Add `CborTransport` and `DualTransport` helpers (`src/cbor-transport.ts`) for use with Workflow SDK spec version 3 (CBOR queue transport). Not yet wired into the default queue — see the upstream PR description for the migration checklist.

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -32,6 +32,7 @@
     "@workflow/errors": "4.1.0-beta.14",
     "@workflow/world": "4.1.0-beta.2",
     "@vercel/queue": "^0.0.0-alpha.29",
+    "cbor-x": "1.6.0",
     "mongodb": "^6.0.0",
     "ulid": "^2.3.0",
     "zod": "^4.1.11"

--- a/packages/mongodb/src/cbor-transport.ts
+++ b/packages/mongodb/src/cbor-transport.ts
@@ -1,0 +1,72 @@
+/**
+ * CBOR-based queue transport utilities.
+ *
+ * Workflow SDK runs at spec version 3+ carry a `runInput` on the first queue
+ * delivery whose `input` field is a `Uint8Array`. JSON serialization does not
+ * round-trip `Uint8Array` values, so any world that wants to opt in to
+ * `SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT` must serialize queue payloads
+ * with CBOR instead.
+ *
+ * These classes mirror the pattern used in `@workflow/world-vercel`:
+ * - `CborTransport` always encodes/decodes CBOR (for new outgoing messages).
+ * - `DualTransport` decodes CBOR first and falls back to JSON, so handlers keep
+ *   accepting any JSON-encoded messages that were in-flight when the transport
+ *   was switched over.
+ *
+ * Wire them into `queue.ts` by replacing `new JsonTransport()` with
+ * `new CborTransport()` for the encode path and `new DualTransport()` for the
+ * HTTP handler decode path. When `opts.specVersion < 3` is passed to `queue()`,
+ * fall back to JSON so older runs continue to use the format they were
+ * created with.
+ */
+
+import type { Transport } from '@vercel/queue';
+import { decode, encode } from 'cbor-x';
+
+export class CborTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    return decode(Buffer.concat(chunks));
+  }
+}
+
+/**
+ * Dual-mode decoder: try CBOR first, fall back to JSON if that fails.
+ * Use this on the receive side while the sender is still transitioning, or to
+ * keep compatibility with JSON-encoded messages that were already queued.
+ */
+export class DualTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    const buffer = Buffer.concat(chunks);
+    try {
+      return decode(buffer);
+    } catch {
+      return JSON.parse(buffer.toString('utf8'));
+    }
+  }
+}

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@workflow/errors": "4.1.0-beta.14",
     "@workflow/world": "4.1.0-beta.2",
+    "@vercel/queue": "^0.0.0-alpha.29",
     "bullmq": "^5.34.0",
     "cbor-x": "1.6.0",
     "ioredis": "^5.4.2",

--- a/packages/redis/src/cbor-transport.ts
+++ b/packages/redis/src/cbor-transport.ts
@@ -1,0 +1,109 @@
+/**
+ * CBOR-based queue transport utilities.
+ *
+ * Workflow SDK runs at spec version 3+ carry a `runInput` on the first queue
+ * delivery whose `input` field is a `Uint8Array`. JSON serialization does not
+ * round-trip `Uint8Array` values, so any world that wants to opt in to
+ * `SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT` must serialize queue payloads
+ * with CBOR instead. BullMQ stores `job.data` as a JSON value, so we CBOR-encode
+ * the payload to a base64 string before queueing and decode it in the worker
+ * processor before POSTing to the workflow HTTP endpoint.
+ *
+ * Wire into `queue.ts`:
+ * - On the send path, wrap `message` with `encodeForBullMq()` before passing it
+ *   to `queue.add()`, and update the worker processor to run `decodeFromBullMq()`
+ *   on `job.data` before forwarding it.
+ * - On the HTTP send, serialize with `CborTransport` and set
+ *   `content-type: application/cbor`.
+ * - On `createQueueHandler`, use `DualTransport` to decode the request body
+ *   (CBOR-first, JSON fallback during rollout).
+ * - When `opts.specVersion < 3` is passed, keep using the JSON path so older
+ *   runs continue to use the format they were created with.
+ */
+
+import type { Transport } from '@vercel/queue';
+import { decode, encode } from 'cbor-x';
+
+/** Prefix on base64 strings stored in BullMQ jobs to mark them as CBOR payloads. */
+export const CBOR_BULLMQ_PREFIX = 'cbor:';
+
+/**
+ * Encode a payload for storage inside BullMQ `job.data`. Returns a discriminated
+ * union so the worker can recognize CBOR payloads and decode them back to a
+ * structured object before forwarding.
+ */
+export function encodeForBullMq(value: unknown): { __cbor: string } {
+  const buffer = encode(value);
+  return {
+    __cbor: CBOR_BULLMQ_PREFIX + Buffer.from(buffer).toString('base64'),
+  };
+}
+
+/**
+ * Decode a payload written by {@link encodeForBullMq}. If the data is not a
+ * CBOR-wrapped object (e.g., an older JSON payload from before the transition),
+ * the value is returned unchanged.
+ */
+export function decodeFromBullMq<T = unknown>(data: unknown): T {
+  if (
+    data &&
+    typeof data === 'object' &&
+    '__cbor' in data &&
+    typeof (data as { __cbor: unknown }).__cbor === 'string'
+  ) {
+    const encoded = (data as { __cbor: string }).__cbor;
+    const body = encoded.startsWith(CBOR_BULLMQ_PREFIX)
+      ? encoded.slice(CBOR_BULLMQ_PREFIX.length)
+      : encoded;
+    return decode(Buffer.from(body, 'base64')) as T;
+  }
+  return data as T;
+}
+
+export class CborTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    return decode(Buffer.concat(chunks));
+  }
+}
+
+/**
+ * Dual-mode decoder: try CBOR first, fall back to JSON if that fails.
+ * Use this on the receive side while the sender is still transitioning, or to
+ * keep compatibility with JSON-encoded messages that were already queued.
+ */
+export class DualTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    const buffer = Buffer.concat(chunks);
+    try {
+      return decode(buffer);
+    } catch {
+      return JSON.parse(buffer.toString('utf8'));
+    }
+  }
+}

--- a/packages/turso/src/cbor-transport.ts
+++ b/packages/turso/src/cbor-transport.ts
@@ -1,0 +1,72 @@
+/**
+ * CBOR-based queue transport utilities.
+ *
+ * Workflow SDK runs at spec version 3+ carry a `runInput` on the first queue
+ * delivery whose `input` field is a `Uint8Array`. JSON serialization does not
+ * round-trip `Uint8Array` values, so any world that wants to opt in to
+ * `SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT` must serialize queue payloads
+ * with CBOR instead.
+ *
+ * These classes mirror the pattern used in `@workflow/world-vercel`:
+ * - `CborTransport` always encodes/decodes CBOR (for new outgoing messages).
+ * - `DualTransport` decodes CBOR first and falls back to JSON, so handlers keep
+ *   accepting any JSON-encoded messages that were in-flight when the transport
+ *   was switched over.
+ *
+ * Wire them into `queue.ts` by replacing `new JsonTransport()` with
+ * `new CborTransport()` for the encode path and `new DualTransport()` for the
+ * HTTP handler decode path. When `opts.specVersion < 3` is passed to `queue()`,
+ * fall back to JSON so older runs continue to use the format they were
+ * created with.
+ */
+
+import type { Transport } from '@vercel/queue';
+import { decode, encode } from 'cbor-x';
+
+export class CborTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    return decode(Buffer.concat(chunks));
+  }
+}
+
+/**
+ * Dual-mode decoder: try CBOR first, fall back to JSON if that fails.
+ * Use this on the receive side while the sender is still transitioning, or to
+ * keep compatibility with JSON-encoded messages that were already queued.
+ */
+export class DualTransport implements Transport<unknown> {
+  readonly contentType = 'application/cbor';
+
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value));
+  }
+
+  async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    const buffer = Buffer.concat(chunks);
+    try {
+      return decode(buffer);
+    } catch {
+      return JSON.parse(buffer.toString('utf8'));
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@workflow/world':
         specifier: 4.1.0-beta.2
         version: 4.1.0-beta.2(zod@4.1.13)
+      cbor-x:
+        specifier: 1.6.0
+        version: 1.6.0
       mongodb:
         specifier: ^6.0.0
         version: 6.21.0
@@ -60,6 +63,9 @@ importers:
 
   packages/redis:
     dependencies:
+      '@vercel/queue':
+        specifier: ^0.0.0-alpha.29
+        version: 0.0.0-alpha.36
       '@workflow/errors':
         specifier: 4.1.0-beta.14
         version: 4.1.0-beta.14


### PR DESCRIPTION
## Summary

[Workflow SDK](https://github.com/vercel/workflow) recently moved the \`@workflow/world-vercel\` queue transport from JSON to CBOR (vercel/workflow#1627). The move is gated behind \`SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT\` (spec version 3) so worlds that don't declare support stay on JSON.

This PR adds the CBOR transport building blocks to each world in this repo so they can eventually opt in. It intentionally does **not** flip any of the queues over — the full migration is larger than this and deserves careful review on a per-world basis.

### What's in the PR

- \`packages/turso/src/cbor-transport.ts\` — \`CborTransport\` + \`DualTransport\` (CBOR-first, JSON fallback) mirroring \`@workflow/world-vercel\`'s implementation.
- \`packages/mongodb/src/cbor-transport.ts\` — same pair. Adds \`cbor-x\` as a dependency (mongodb didn't have it yet).
- \`packages/redis/src/cbor-transport.ts\` — same pair plus \`encodeForBullMq\`/\`decodeFromBullMq\` helpers. BullMQ stores \`job.data\` as a JSON value, so the CBOR payload is wrapped as a base64 string on the way in and unwrapped in the processor before the HTTP POST. Adds \`@vercel/queue\` as a dependency to match the other packages.
- Three changesets (\`patch\`) so these show up in the next release train.

### Background from upstream

- **Resilient start (vercel/workflow#1537)** added a \`runInput\` payload that rides on the first queue delivery. The input field is a \`Uint8Array\`.
- **CBOR queue transport (vercel/workflow#1627)** flipped \`@workflow/world-vercel\` over because JSON drops \`Uint8Array\` on the floor. It bumped \`SPEC_VERSION_CURRENT\` to 3, so any world whose \`specVersion\` is 3+ needs a transport that preserves \`Uint8Array\`.
- **Spec version gate (vercel/workflow#1658)** keeps worlds on spec v2 by default, which is why the worlds in this repo are still compatible today — the SDK does not send them \`runInput\` over the queue.

In short: nothing is breaking today because these worlds haven't declared \`specVersion\`. But they also can't opt in to resilient start (or any future CBOR-only feature) until a transport like this is wired up.

### Why not wire it in here?

These packages currently pin \`@workflow/world: 4.1.0-beta.2\`, which is a pre-v5 shape (flat \`writeToStream\`/\`readFromStream\` on the \`World\`). \`@workflow/world@5.x\` restructures streams into a nested \`streams.{ write, close, get, list, getChunks, getInfo }\` interface and requires \`runId\` on reads. Migrating to v5 is a prerequisite for spec v3 and I didn't want to bundle that migration into this PR — it's significant enough to deserve its own review pass (and will break the current consumer story on 4.1.x betas).

### Suggested follow-up checklist

For each world (turso, mongodb, redis):
1. Bump \`@workflow/world\` to \`^5.0.0-beta.1\` (the first 5.x beta to export \`SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT\`) and corresponding \`@workflow/errors\` / \`@workflow/world-testing\` versions.
2. Migrate the world to the new \`streams.*\` shape (\`writeToStream(name, runId, chunk)\` → \`streams.write(runId, name, chunk)\`, etc.). This is the bulk of the work.
3. Swap \`new JsonTransport()\` for \`new CborTransport()\` on the send path and \`new DualTransport()\` on the receive path in \`queue.ts\`. For Redis, wrap \`job.data\` with \`encodeForBullMq\` / \`decodeFromBullMq\` at the queue/worker boundary.
4. For Turso, change the \`queue_messages.payload\` column from \`TEXT\` to \`BLOB\` (or base64-wrap the CBOR bytes) — CBOR is binary and will not round-trip as UTF-8 text.
5. Honor \`opts?.specVersion\` in \`queue()\`: fall back to \`JsonTransport\` when \`specVersion < 3\` so existing runs continue to use the format they were created with.
6. Declare \`specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT\` on the exported world so the SDK creates new runs at v3.
7. Extend the e2e tests to exercise \`runInput\` (start a workflow with a binary input and assert it round-trips).

Happy to split out per-world follow-up PRs if that's easier to review.

## Test plan

- [x] \`pnpm typecheck\` passes for \`@workflow-worlds/{turso,mongodb,redis}\`.
- [ ] Once wired in: existing e2e suite passes + new test exercising \`Uint8Array\` \`runInput\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)